### PR TITLE
feat(): Add postcss-import configuration to fix layer warnings

### DIFF
--- a/universal-scripts/build.conf.d/30-css.js
+++ b/universal-scripts/build.conf.d/30-css.js
@@ -4,6 +4,7 @@ import PostCssUrl from 'postcss-url'
 import postcssCascadeLayers from '@csstools/postcss-cascade-layers'
 import PostCssPresetEnv from 'postcss-preset-env'
 import PostCssNested from 'postcss-nested'
+import PostCssImport from 'postcss-import'
 import PostCssNormalize from 'postcss-normalize'
 import { triggerHook } from '../lib/plugins/trigger.js'
 
@@ -27,6 +28,7 @@ const getInitialStyleConfig = (opts) => {
         ident: 'postcss',
         to: 'src/static',
         plugins: [
+          PostCssImport(),
           PostCssPresetEnv({
             autoprefixer: { grid: true },
             features: {


### PR DESCRIPTION
- Add PostCssImport to the beginning of PostCSS plugins chain
- Fix warnings when using @import with @layer directives
- Improve developer experience with modern CSS layer specification